### PR TITLE
Handle SIGINT and uncaughtException as well

### DIFF
--- a/client-cert-proxy.js
+++ b/client-cert-proxy.js
@@ -11,8 +11,12 @@ const proxy = httpProxy.createProxyServer({
   secure: false
 }).listen(process.env.PROXY_PATH);
 
-process.on('SIGTERM', function () {
+function closeProxyAndExit() {
   proxy.close(function () {
     process.exit(0);
   });
-});
+}
+
+process.on('SIGTERM', closeProxyAndExit);
+process.on('SIGINT', closeProxyAndExit);
+process.on('uncaughtException', closeProxyAndExit);


### PR DESCRIPTION
I still occasionally have to delete the proxy and restart brew, so there must be some unhandled exit signals being sent to it. I've added a handler for SIGINT (which definitely kills it without removing the proxy) and maybe there is an error happening that we don't know about :/

It's a bit of a punt (Cos I'm really not sure what would be siginting node), but it can't hurt.